### PR TITLE
Simplify decorated by itself case

### DIFF
--- a/src/Attribute/DecoratorAttribute.php
+++ b/src/Attribute/DecoratorAttribute.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Yceruto\Decorator\Attribute;
 
+use Yceruto\Decorator\DecoratorInterface;
+
 /**
  * Abstract class for all decorator attributes.
  */
@@ -20,6 +22,10 @@ abstract class DecoratorAttribute
 {
     public function decoratedBy(): string
     {
+        if ($this instanceof DecoratorInterface) {
+            return static::class;
+        }
+
         return static::class.'Decorator';
     }
 }

--- a/tests/Fixtures/Decorator/Json.php
+++ b/tests/Fixtures/Decorator/Json.php
@@ -27,9 +27,4 @@ final class Json extends DecoratorAttribute implements DecoratorInterface
             return json_encode($result, JSON_THROW_ON_ERROR);
         };
     }
-
-    public function decoratedBy(): string
-    {
-        return self::class;
-    }
 }


### PR DESCRIPTION
Before:
```php
#[\Attribute(\Attribute::TARGET_METHOD)]
final class Json extends DecoratorAttribute implements DecoratorInterface
{
    public function decorate(\Closure $func): \Closure
    {
        // ...
    }

    public function decoratedBy(): string
    {
        return self::class;
    }
}
```
After:
```php
#[\Attribute(\Attribute::TARGET_METHOD)]
final class Json extends DecoratorAttribute implements DecoratorInterface
{
    public function decorate(\Closure $func): \Closure
    {
        // ...
    }
}
```
It’s no longer necessary to implement decoratedBy() when the attribute implements the decorator adapter itself.