### PR TITLE
Add support for invokable objects and multipurpose decorator attributes

### DIFF
--- a/src/Attribute/DecoratorAttribute.php
+++ b/src/Attribute/DecoratorAttribute.php
@@ -16,9 +16,9 @@ namespace Yceruto\Decorator\Attribute;
 use Yceruto\Decorator\DecoratorInterface;
 
 /**
- * Abstract class for all decorator attributes.
+ * Abstract class for all decorator attributes with default convention.
  */
-abstract class DecoratorAttribute
+abstract class DecoratorAttribute implements DecoratorAttributeInterface
 {
     public function decoratedBy(): string
     {

--- a/src/Attribute/DecoratorAttributeInterface.php
+++ b/src/Attribute/DecoratorAttributeInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Decorator package.
+ *
+ * (c) Yonel Ceruto <open@yceruto.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yceruto\Decorator\Attribute;
+
+/**
+ * Interface for all decorator attributes.
+ */
+interface DecoratorAttributeInterface
+{
+    /**
+     * @return string the class or id of the decorator associated with this attribute
+     */
+    public function decoratedBy(): string;
+}

--- a/tests/CallableDecoratorTest.php
+++ b/tests/CallableDecoratorTest.php
@@ -22,6 +22,7 @@ use Yceruto\Decorator\Resolver\DecoratorResolver;
 use Yceruto\Decorator\Tests\Fixtures\Controller\CreateTaskController;
 use Yceruto\Decorator\Tests\Fixtures\Decorator\Logging;
 use Yceruto\Decorator\Tests\Fixtures\Decorator\LoggingDecorator;
+use Yceruto\Decorator\Tests\Fixtures\Handler\InvokableMessageHandler;
 use Yceruto\Decorator\Tests\Fixtures\Handler\Message;
 use Yceruto\Decorator\Tests\Fixtures\Handler\MessageHandler;
 use Yceruto\Decorator\Tests\Fixtures\Logger\TestLogger;
@@ -106,6 +107,10 @@ class CallableDecoratorTest extends TestCase
 
     public static function getCallableProvider(): iterable
     {
+        yield 'non_decorated_function' => [
+            strtoupper(...), ['bar'], 'BAR', [],
+        ];
+
         #[Logging]
         function foo(string $bar): string
         {
@@ -129,8 +134,24 @@ class CallableDecoratorTest extends TestCase
 
         $message = new Message();
         $handler = new MessageHandler();
+        $invokableHandler = new InvokableMessageHandler();
 
         yield 'invokable_object' => [
+            $invokableHandler, [$message], $message, [
+                [
+                    'level' => 'debug',
+                    'message' => 'Before calling func',
+                    'context' => ['args' => 1],
+                ],
+                [
+                    'level' => 'debug',
+                    'message' => 'After calling func',
+                    'context' => ['result' => $message],
+                ],
+            ],
+        ];
+
+        yield 'invokable_method' => [
             $handler, [$message], $message, [
                 [
                     'level' => 'debug',

--- a/tests/Fixtures/Controller/CreateTaskController.php
+++ b/tests/Fixtures/Controller/CreateTaskController.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Yceruto\Decorator\Tests\Fixtures\Controller;
 
 use Yceruto\Decorator\Tests\Fixtures\Decorator\Json;
-use Yceruto\Decorator\Tests\Fixtures\Decorator\LoggingJson;
 use Yceruto\Decorator\Tests\Fixtures\Decorator\Logging;
+use Yceruto\Decorator\Tests\Fixtures\Decorator\LoggingJson;
 
 final readonly class CreateTaskController
 {

--- a/tests/Fixtures/Decorator/Logging.php
+++ b/tests/Fixtures/Decorator/Logging.php
@@ -16,7 +16,7 @@ namespace Yceruto\Decorator\Tests\Fixtures\Decorator;
 use Psr\Log\LogLevel;
 use Yceruto\Decorator\Attribute\DecoratorAttribute;
 
-#[\Attribute(\Attribute::TARGET_FUNCTION | \Attribute::TARGET_METHOD)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]
 final class Logging extends DecoratorAttribute
 {
     public function __construct(

--- a/tests/Fixtures/Handler/InvokableMessageHandler.php
+++ b/tests/Fixtures/Handler/InvokableMessageHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Decorator package.
+ *
+ * (c) Yonel Ceruto <open@yceruto.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Yceruto\Decorator\Tests\Fixtures\Handler;
+
+use Yceruto\Decorator\Tests\Fixtures\Decorator\Logging;
+
+#[Logging]
+final readonly class InvokableMessageHandler
+{
+    public function __invoke(Message $message): Message
+    {
+        return $message;
+    }
+}


### PR DESCRIPTION
Two new features have been implemented here:

1. New `DecoratorAttributeInterface` for multipurpose attribute: This is useful when you can’t extend the abstract `DecoratorAttribute` class because your custom decorator attribute already extends another class. In such cases, you can implement this interface and manually define the `decoratedBy()` method.
2. Detecting the decorator attribute at the top of the class when the `__invoke()` method is called and there is no decorator attributes linked to it. Example:
```php
#[Transactional]
class MyMessageHandler
{
    public function __invoke(Message $message): Message
    {
        return $message;
    }
}
```
